### PR TITLE
Made the alert dialog's content scrollable

### DIFF
--- a/lib/widgets/quickalert_dialog.dart
+++ b/lib/widgets/quickalert_dialog.dart
@@ -113,8 +113,10 @@ class QuickAlert {
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(borderRadius),
       ),
-      content: QuickAlertContainer(
-        options: options,
+      content: SingleChildScrollView(
+        child: QuickAlertContainer(
+          options: options,
+        ),
       ),
     );
 


### PR DESCRIPTION
When used multiple widgets such as 4-5 text-form fields inside dialog box, it threw overflow error.

![image_2022-11-05_22-09-23](https://user-images.githubusercontent.com/57010722/200131901-7121de58-8c3a-4cf2-a340-8984a6a5c44e.png)

To fix this, I made the content scrollable.

![error](https://user-images.githubusercontent.com/57010722/200131874-e2a08b36-ae65-4907-b992-d509f0c3ef0e.png)
