### PR TITLE
Option to disable back button completely

### DIFF
--- a/lib/widgets/quickalert_dialog.dart
+++ b/lib/widgets/quickalert_dialog.dart
@@ -117,22 +117,18 @@ class QuickAlert {
       width: width,
     );
     
-    Widget child = AlertDialog(
-      contentPadding: EdgeInsets.zero,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(borderRadius),
-      ),
-      content: QuickAlertContainer(
-        options: options,
+    final child = WillPopScope(
+      onWillPop: () => Future.value(!disableBackBtn),
+      child: AlertDialog(
+        contentPadding: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(borderRadius),
+        ),
+        content: QuickAlertContainer(
+          options: options,
+        ),
       ),
     );
-
-    if (disableBackBtn) {
-      child = WillPopScope(
-        onWillPop: () => Future.value(false),
-        child: child,
-      );
-    }
 
     return showGeneralDialog(
       barrierColor: barrierColor ?? Colors.black.withOpacity(0.5),

--- a/lib/widgets/quickalert_dialog.dart
+++ b/lib/widgets/quickalert_dialog.dart
@@ -81,6 +81,9 @@ class QuickAlert {
 
     /// Determines how long the dialog stays open for before closing, [default] is null. When it is null, it won't auto close
     Duration? autoCloseDuration,
+
+    /// Disable Back Button
+    bool disableBackBtn = false,
   }) {
     var timer;
     if (autoCloseDuration != null) {
@@ -113,8 +116,8 @@ class QuickAlert {
       customAsset: customAsset,
       width: width,
     );
-
-    final child = AlertDialog(
+    
+    Widget child = AlertDialog(
       contentPadding: EdgeInsets.zero,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(borderRadius),
@@ -123,6 +126,13 @@ class QuickAlert {
         options: options,
       ),
     );
+
+    if (disableBackBtn) {
+      child = WillPopScope(
+        onWillPop: () => Future.value(false),
+        child: child,
+      );
+    }
 
     return showGeneralDialog(
       barrierColor: barrierColor ?? Colors.black.withOpacity(0.5),


### PR DESCRIPTION
Added a parameter called disableBackBtn. Default is false. If set to true, then the user cannot back out of the dialog using the Android back button (Simple WillPopScope stuff).