### PR TITLE
Now onConfirmBtnTap, onCancelBtnTap callback functions will return current context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,31 @@
+## 1.1.0
+
+- Now onConfirmBtnTap, onCancelBtnTap callback functions will return current context so that dialog can be popped later by developer. Now with custom button code developer can pop alert by its context rather than the parent context that is passed during alert building process.
+
 ## 1.0.2
 
-* Addition of more options to provide more control over the dialog
-* Documentation Updated
+- Addition of more options to provide more control over the dialog
+- Documentation Updated
 
 ## 1.0.1
 
-* ReadME updated
-* Documentation Typos Corrected
+- ReadME updated
+- Documentation Typos Corrected
 
 ## 1.0.0
 
-* Requested Updates
-* Background Color Added
-* Title Color Added
-* Text Color Added
-* Barrier Color Added
+- Requested Updates
+- Background Color Added
+- Title Color Added
+- Text Color Added
+- Barrier Color Added
 
 ## 0.0.2
 
-* ReadME updated
-* Documentation Comments Added
+- ReadME updated
+- Documentation Comments Added
 
 ## 0.0.1
 
-* Initial Release
-* Display animated alert dialogs such as success, error, warning, confirm, loading or even a custom dialog.
+- Initial Release
+- Display animated alert dialogs such as success, error, warning, confirm, loading or even a custom dialog.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -92,8 +92,8 @@ class _MyHomePageState extends State<MyHomePage> {
     final confirmAlert = buildButton(
       onTap: () {
         QuickAlert.show(
-          onCancelBtnTap: () {
-            Navigator.pop(context);
+          onCancelBtnTap: (ctx) {
+            Navigator.pop(ctx);
           },
           context: context,
           type: QuickAlertType.confirm,
@@ -154,7 +154,7 @@ class _MyHomePageState extends State<MyHomePage> {
             keyboardType: TextInputType.phone,
             onChanged: (value) => message = value,
           ),
-          onConfirmBtnTap: () async {
+          onConfirmBtnTap: (ctx) async {
             if (message.length < 5) {
               await QuickAlert.show(
                 context: context,

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -182,7 +182,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -235,6 +235,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -344,7 +345,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -423,7 +424,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -470,7 +471,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/models/quickalert_options.dart
+++ b/lib/models/quickalert_options.dart
@@ -31,10 +31,10 @@ class QuickAlertOptions {
   bool? barrierDismissible = false;
 
   /// Triggered when confirm button is tapped
-  VoidCallback? onConfirmBtnTap;
+  void Function(BuildContext ctx)? onConfirmBtnTap;
 
   /// Triggered when cancel button is tapped
-  VoidCallback? onCancelBtnTap;
+  void Function(BuildContext ctx)? onCancelBtnTap;
 
   /// Confirmation button text
   String? confirmBtnText;

--- a/lib/widgets/quickalert_buttons.dart
+++ b/lib/widgets/quickalert_buttons.dart
@@ -39,7 +39,7 @@ class QuickAlertButtons extends StatelessWidget {
         onTap: () {
           options!.timer?.cancel();
           options!.onConfirmBtnTap != null
-              ? options!.onConfirmBtnTap!()
+              ? options!.onConfirmBtnTap!.call(context)
               : Navigator.pop(context);
         });
 
@@ -62,7 +62,7 @@ class QuickAlertButtons extends StatelessWidget {
         onTap: () {
           options!.timer?.cancel();
           options!.onCancelBtnTap != null
-              ? options!.onCancelBtnTap!()
+              ? options!.onCancelBtnTap!.call(context)
               : Navigator.pop(context);
         });
 

--- a/lib/widgets/quickalert_dialog.dart
+++ b/lib/widgets/quickalert_dialog.dart
@@ -38,10 +38,10 @@ class QuickAlert {
     bool barrierDismissible = true,
 
     /// Triggered when confirm button is tapped
-    VoidCallback? onConfirmBtnTap,
+    void Function(BuildContext ctx)? onConfirmBtnTap,
 
     /// Triggered when cancel button is tapped
-    VoidCallback? onCancelBtnTap,
+    void Function(BuildContext ctx)? onCancelBtnTap,
 
     /// Confirmation button text
     String confirmBtnText = 'Okay',
@@ -128,7 +128,7 @@ class QuickAlert {
       customAsset: customAsset,
       width: width,
     );
-    
+
     final child = WillPopScope(
       onWillPop: () => Future.value(!disableBackBtn),
       child: AlertDialog(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quickalert
 description: With QuickAlert, instantly display animated alert dialogs such as success, error, warning, confirm, loading or even a custom dialog.
-version: 1.0.2
+version: 1.1.0
 homepage: https://quickalert.belovance.com
 repository: https://github.com/belovance/QuickAlert
 
@@ -26,7 +26,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # To add assets to your package, add an assets section, like this:
   assets:
     - assets/


### PR DESCRIPTION
Solved problem where when writing custom onConfirmBtnTap , popping the alert causes the screen to pop as we are popping top level context.

```
// In below example the alert stays on screen in macos as the we are popping the top level context. Popping it causes current screen to pop.
QuickAlert.show(
              context: context,
              type: QuickAlertType.error,
              title: "Deny rewards ?",
              cancelBtnText: 'Back',
              showCancelBtn: true,
              showConfirmBtn: true,
              //autoCloseDuration: const Duration(seconds: 10),
              onConfirmBtnTap: () {
// Some custom code
                Navigator.pop(context);
              },
            )
```

```
//Solution
// With below code we can catch the result too, thus detecting wheather the closure of alert is done by cancel/ok button or barrier dissmissable.
var result = await QuickAlert.show(
              context: context,
              type: QuickAlertType.error,
              title: "Deny rewards ?",
              cancelBtnText: 'Back',
              showCancelBtn: true,
              showConfirmBtn: true,
              //autoCloseDuration: const Duration(seconds: 10),
              onConfirmBtnTap: (ctx) {
// Some custom code
                Navigator.pop(ctx, true);
              },
            )
```